### PR TITLE
Affiche l'adresse email sur la page de contact

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -20,7 +20,7 @@
         <section class="container">
             <div class="inline-cta" aria-label="Contact email">
                 <p>Pour toute demande, vous pouvez nous écrire à l'adresse mail suivante :</p>
-                <a href="mailto:contact@holdinginfine.com" class="btn-contact">Écrire un email</a>
+                <a href="mailto:contact@holdinginfine.com" class="btn-contact">contact@holdinginfine.com</a>
             </div>
             <p style="margin-top:1rem;"><strong>Chemin des Cigognes 4 - CH 1162 St Prex · Switzerland</strong></p>
         </section>


### PR DESCRIPTION
## Summary
- Replace generic "Écrire un email" link text with the actual address `contact@holdinginfine.com`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897cdfd9c4083309df001b1af7035d6